### PR TITLE
Use -Wno-error=stringop-truncation for libcecb.a

### DIFF
--- a/build/unix/libcecb/Makefile
+++ b/build/unix/libcecb/Makefile
@@ -3,7 +3,7 @@ include ../rules.mak
 
 vpath %.c ../../../libcecb
 
-CFLAGS	+= -I../../../include -Wall
+CFLAGS	+= -I../../../include -Wall -Wno-error=stringop-truncation
 
 %.a:
 	$(AR) -r $@ $^


### PR DESCRIPTION
Since path->filename is only 8 bytes, I assume the code is valid,
and null termination is not needed in this struct. 

My current cc (cc (Debian 13.2.0-4) 13.2.0; possibly modified locally)
is giving this warning, which is promoted to an error.  

```
cc -Dunix -DUNIX -O3 -I. -I../../../include -Wall -DTOOLSHED_VERSION=\"2.2\" -D_FILE_OFFSET_BITS=64 -Wno-unused-result -Werror -I../../../include -Wall   -c -o libcebcopen.o ../../../libcecb/libcebcopen.c
In function ‘validate_pathlist’, 
    inlined from ‘_cecb_create’ at ../../../libcecb/libcebcopen.c:44:7:
../../../libcecb/libcebcopen.c:493:17: error: ‘strncpy’ specified bound 8 equals destination size [-Werror=stringop-truncation]                                                                                                                     
  493 |                 strncpy(path->filename, p, 8);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘validate_pathlist’,
    inlined from ‘_cecb_open’ at ../../../libcecb/libcebcopen.c:252:7:
../../../libcecb/libcebcopen.c:493:17: error: ‘strncpy’ specified bound 8 equals destination size [-Werror=stringop-truncation]
  493 |                 strncpy(path->filename, p, 8);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
cc1: all warnings being treated as errors      
make[2]: *** [<builtin>: libcebcopen.o] Error 1
make[2]: Leaving directory '/home/strick/nando/coco-shelf/toolshed/build/unix/libcecb'
```