### PR TITLE
Removed strncpy in libcecb when filling in the filename buffer.

### DIFF
--- a/build/unix/libcecb/Makefile
+++ b/build/unix/libcecb/Makefile
@@ -3,7 +3,7 @@ include ../rules.mak
 
 vpath %.c ../../../libcecb
 
-CFLAGS	+= -I../../../include -Wall -Wno-error=stringop-truncation
+CFLAGS	+= -I../../../include -Wall
 
 %.a:
 	$(AR) -r $@ $^

--- a/libcecb/libcebcopen.c
+++ b/libcecb/libcebcopen.c
@@ -469,8 +469,8 @@ static error_code validate_pathlist(cecb_path_id path, char *pathlist)
 {
 	error_code ec = 0;
 	char *p;
-	int i;
-
+	int i, j;
+	
 	/* 1. Validate the pathlist. */
 
 	if ((p = strchr(pathlist, ',')) == NULL)
@@ -490,12 +490,18 @@ static error_code validate_pathlist(cecb_path_id path, char *pathlist)
 
 		p++;
 
-		strncpy(path->filename, p, 8);
-
-		/* Space fill remaining characters */
-		for (i = strlen(p); i < 8; i++)
-			path->filename[i] = ' ';
-
+		/* Copy characters and space fill buffer */
+		for (i = 0, j = 0; j < 8; j++)
+		{
+			if (p[i] != 0)
+			{
+				path->filename[j] = p[i++];
+			}
+			else
+			{
+				path->filename[j] = ' ';
+			}
+		}
 	}
 
 	/* 2. Return. */


### PR DESCRIPTION
This removed the recent make file change to add an exception to werror.