### PR TITLE
Fix HDBDOS sources to account for a change in LWASM concerning RMB and re-ORG statements.

### DIFF
--- a/hdbdos/preload.asm
+++ b/hdbdos/preload.asm
@@ -6,13 +6,19 @@
 
 * DECB binary file preamble
 
+	* Trick lwasm into thinking the preamble is part of the
+	* code, and it starts 5 bytes before we really want the
+	* code to start.
+	org	$4fd0-5
+
 	fcb     $00		Preamble flag
 	fdb	$2030		Length of data block
 	fdb	$4FD0		Load address
 
 * Entry point from Basic
 
-	org	$4fd0		This code covers $4fd0-$4fff
+	* Note: Don't use ORG here, it confuses lwasm.
+	* org	$4fd0		This code covers $4fd0-$4fff
 	orcc	#$50		Disable interrupts
 	lda	>$fffe		Check RESET vector
 	cmpa	#$8c		Points to CoCo3 reset code?


### PR DESCRIPTION
LWASM in raw mode gets confused by RMB statements. 
Sometimes it thinks it should generate \000 bytes into the binary. 
That seems to be after it has already been generating code.

There's also a problem if you ORG to a different address
in the middle of generating raw bytes.   (It's OK to ORG
to the same address you are already at.)

First I tried making a change to LWASM, but it broke something else.  
It turns out I can fix the HDBDOS sources instead, so the confusing situations do not occur.

How to tell if it works:  All the .rom files are exactly 8192 bytes long, and preload is 53 bytes long,
and makewav doesn't complain about the preamble matching.

How to tell that is is broken:   All the .rom files are 3 bytes too long, and preload is only 5 bytes long,
and makewav has fatal errors. 

(I've been using the current "lwasm from lwtools 4.22")