### PR TITLE
Free allocated buffers during decb copy (and cecb copy)

### DIFF
--- a/cecb/cecbcopy.c
+++ b/cecb/cecbcopy.c
@@ -504,7 +504,7 @@ static error_code CopyCECBFile(char *srcfile, char *dstfile, int eolTranslate,
 
 	if (tokTranslate != 0)
 	{
-		u_char *xx_tokenize_buffer;
+		u_char *xx_tokenize_buffer = NULL;
 		u_int xx_tokenize_size;
 
 		if (tokTranslate == 1) /* entokenize */
@@ -557,7 +557,11 @@ static error_code CopyCECBFile(char *srcfile, char *dstfile, int eolTranslate,
 			buffer_size = xx_tokenize_size;
 		}
 		else
+		{
+			if (xx_tokenize_buffer)
+				free(xx_tokenize_buffer);
 			return ec;
+		}
 	}
 
 	if (eolTranslate == 1)

--- a/decb/decbcopy.c
+++ b/decb/decbcopy.c
@@ -364,7 +364,7 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 		{
 			if (buffer[0] == 0xff)
 			{
-				u_char *detokenize_buffer;
+				u_char *detokenize_buffer = NULL;
 				u_int detokenize_size;
 
 				/* File is already a tokenized BASIC file, de-tokenize it */
@@ -383,11 +383,15 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 					data_type = 0xff;
 				}
 				else
+				{
+					if (detokenize_buffer != NULL)
+						free(detokenize_buffer);
 					return -1;
+				}
 			}
 			else
 			{
-				unsigned char *entokenize_buffer;
+				unsigned char *entokenize_buffer = NULL;
 				u_int entokenize_size;
 
 				/* Tokenized file */
@@ -409,7 +413,11 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 
 				}
 				else
+				{
+					if (entokenize_buffer != NULL)
+						free(entokenize_buffer);
 					return -1;
+				}
 			}
 		}
 

--- a/decb/decbcopy.c
+++ b/decb/decbcopy.c
@@ -285,7 +285,7 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 	coco_path_id path;
 	coco_path_id destpath;
 	int mode = FAM_NOCREATE | FAM_WRITE;
-	unsigned char *buffer;
+	unsigned char *buffer = NULL;
 	char *translation_buffer;
 	u_int new_translation_size;
 	u_int buffer_size;
@@ -518,6 +518,10 @@ static error_code CopyDECBFile(char *srcfile, char *dstfile, int eolTranslate,
 			}
 		}
 	}
+
+	// free whatever buffer ended up being
+	if (buffer)
+		free(buffer);
 
 	_coco_close(path);
 	_coco_close(destpath);


### PR DESCRIPTION
Fixes a leak in decb.

Applies the same check to cecb, though I don't have a test case for that.