### PR TITLE
unittests: define and use new ASSERT_MEM_EQUALS macro

### DIFF
--- a/unittest/libtoolshedtest.c
+++ b/unittest/libtoolshedtest.c
@@ -129,14 +129,14 @@ void test_native2coco()
 	u_int newSize;
 
 	NativeToCoCo(TEST_LF_DATA, strlen(TEST_LF_DATA), &newBuffer, &newSize);
-	ASSERT_STRING_EQUALS(TEST_COCO_DATA, newBuffer);
 	ASSERT_EQUALS(strlen(TEST_COCO_DATA), newSize);
+	ASSERT_MEM_EQUALS(TEST_COCO_DATA, newBuffer, newSize);
 
 	free(newBuffer);
 
 	NativeToCoCo(TEST_CRLF_DATA, strlen(TEST_CRLF_DATA), &newBuffer, &newSize);
-	ASSERT_STRING_EQUALS(TEST_COCO_DATA, newBuffer);
 	ASSERT_EQUALS(strlen(TEST_COCO_DATA), newSize);
+	ASSERT_MEM_EQUALS(TEST_COCO_DATA, newBuffer, newSize);
 
 	free(newBuffer);
 }
@@ -149,11 +149,11 @@ void test_coco2native()
 
 	CoCoToNative(TEST_COCO_DATA, strlen(TEST_COCO_DATA), &newBuffer, &newSize);
 #ifdef WIN32
-	ASSERT_STRING_EQUALS(TEST_CRLF_DATA, newBuffer);
 	ASSERT_EQUALS(strlen(TEST_CRLF_DATA), newSize);
+	ASSERT_MEM_EQUALS(TEST_CRLF_DATA, newBuffer, newSize);
 #else
-	ASSERT_STRING_EQUALS(TEST_LF_DATA, newBuffer);
 	ASSERT_EQUALS(strlen(TEST_LF_DATA), newSize);
+	ASSERT_MEM_EQUALS(TEST_LF_DATA, newBuffer, newSize);
 #endif
 	free(newBuffer);
 }

--- a/unittest/tinytest.h
+++ b/unittest/tinytest.h
@@ -55,6 +55,7 @@
 #define ASSERT_EQUALS(expected, actual) ASSERTV((#actual), actual, (expected) == (actual))
 #define ASSERT_NEQUALS(expected, actual) ASSERTV((#actual), actual, (expected) != (actual))
 #define ASSERT_STRING_EQUALS(expected, actual) ASSERT((#actual), strcmp((expected),(actual)) == 0)
+#define ASSERT_MEM_EQUALS(expected, actual, size) ASSERT((#actual), memcmp((expected),(actual),(size)) == 0)
 
 /* Run a test() function */
 #define RUN(test_function) tt_execute((#test_function), (test_function))


### PR DESCRIPTION
The macro takes a size and does a memcmp()

Used in unittest/libtoolshedtest.c because the buffers resulting from NativeToCoCo() and CoCoToNative() are _not_ nul-terminated.

Obtained buffer size is tested before the contents (else that could still overrun!).