### PR TITLE
os9 comand logical sector format fix

### DIFF
--- a/build/unix/unittest/Makefile
+++ b/build/unix/unittest/Makefile
@@ -4,8 +4,8 @@ include ../rules.mak
 vpath %.c ../../../unittest
 
 LDLIBS += -L../libtoolshed -L../libcoco -L../libcecb -L../libdecb \
-          -L../librbf -L../libmisc -L../libnative -L../libsys \
-          -ltoolshed -lcoco -lcecb -ldecb -lrbf -lmisc -lnative -lsys -lm
+          -L../librbf -L../libnative -L../libmisc -L../libsys \
+          -ltoolshed -lcoco -lcecb -ldecb -lrbf -lnative -lmisc -lsys -lm
 
 TESTS = librbftest libdecbtest libcecbtest libtoolshedtest os9commandtest
 

--- a/build/unix/unittest/Makefile
+++ b/build/unix/unittest/Makefile
@@ -7,7 +7,7 @@ LDLIBS += -L../libtoolshed -L../libcoco -L../libcecb -L../libdecb \
           -L../librbf -L../libmisc -L../libnative -L../libsys \
           -ltoolshed -lcoco -lcecb -ldecb -lrbf -lmisc -lnative -lsys -lm
 
-TESTS = librbftest libdecbtest libcecbtest libtoolshedtest
+TESTS = librbftest libdecbtest libcecbtest libtoolshedtest os9commandtest
 
 testall: $(TESTS)
 ifeq (,$(NOTEST))
@@ -15,6 +15,7 @@ ifeq (,$(NOTEST))
 	./libdecbtest
 	./libcecbtest
 	./libtoolshedtest
+	./os9commandtest
 endif
 
 clean:

--- a/os9/os9format.c
+++ b/os9/os9format.c
@@ -37,7 +37,7 @@ static char const *const helpMessage[] = {
 	"     -szX = sectors for track 0 (default = 18)\n",
 	"     -dr  = format a Dragon disk\n",
 	" Hard Drive Options:\n",
-	"     -lX  = number of logical sectors\n",
+	"     -lX  = number of logical sectors (floppy options ignored)\n",
 	NULL
 };
 
@@ -51,7 +51,7 @@ int os9format(int argc, char **argv)
 	int tracks = 35;
 	int heads = 1;
 	int sectorsPerTrack = DEF_SECTORS_TRACK;
-	int sectorsTrack0 = DEF_SECTORS_TRACK;
+	int sectorsTrack0 = 0;   /* mark as unset */
 	int bytesPerSector = 256;
 	int tpi = 48;		/* 48 tpi */
 	int density = 1;	/* double density */
@@ -185,11 +185,6 @@ int os9format(int argc, char **argv)
 
 					case 't':
 						sectorsPerTrack = atoi(p + 2);
-						// Change sectors on track 0 only if it's not already been changed.
-						if (DEF_SECTORS_TRACK == sectorsTrack0)
-						{
-							sectorsTrack0 = sectorsPerTrack;
-						}
 						break;
 					
 					case 'z':
@@ -245,6 +240,12 @@ int os9format(int argc, char **argv)
 		}
 	}
 
+	/* match sectors on track 0 only if it's unset. */
+	if (sectorsTrack0 == 0)
+	{
+		sectorsTrack0 = sectorsPerTrack;
+	}
+
 	/* if logicalSectors != 0, then format as a hard drive image */
 	if (logicalSectors != 0)
 	{
@@ -270,6 +271,7 @@ int os9format(int argc, char **argv)
 			if (logicalSectors % i == 0)
 			{
 				sectorsPerTrack = logicalSectors / i;
+				sectorsTrack0 = sectorsPerTrack;
 				heads = i;
 				i = 0;
 			}
@@ -289,7 +291,7 @@ int os9format(int argc, char **argv)
 
 			error_code ec =
 				_os9_format(argv[i], os968k, tracks,
-					    sectorsPerTrack,sectorsTrack0,
+					    sectorsPerTrack, sectorsTrack0,
 					    heads, bytesPerSector, &clusterSize,
 					    diskName, sectorAllocationSize,
 					    tpi, density, formatEntire,

--- a/unittest/os9commandtest.c
+++ b/unittest/os9commandtest.c
@@ -25,12 +25,11 @@ void test_os9_command_format()
 	ASSERT_EQUALS(0, ec);
 	ASSERT_EQUALS(65000*256, size);
 
-	ec = _os9_makdir("test.dsk,/CMDS");
-	ASSERT_EQUALS(0, ec);
-		
 	ec = _native_close(nativepath);
 	ASSERT_EQUALS(0, ec);
 	
+	ec = _os9_makdir("test.dsk,/CMDS");
+	ASSERT_EQUALS(0, ec);
 }
 
 int main()

--- a/unittest/os9commandtest.c
+++ b/unittest/os9commandtest.c
@@ -24,7 +24,10 @@ void test_os9_command_format()
 	ec = _native_gs_size(nativepath, &size);	
 	ASSERT_EQUALS(0, ec);
 	ASSERT_EQUALS(65000*256, size);
-	
+
+	ec = _os9_makdir("test.dsk,/CMDS");
+	ASSERT_EQUALS(0, ec);
+		
 	ec = _native_close(nativepath);
 	ASSERT_EQUALS(0, ec);
 	

--- a/unittest/os9commandtest.c
+++ b/unittest/os9commandtest.c
@@ -1,0 +1,41 @@
+/*
+ * ALWAYS BE TESTING!!!
+ *
+ * ALWAYS BE WRITING MORE TESTS!!!
+ *
+ * THIS WORK IS **NEVER** DONE!!!
+ */
+
+#include "tinytest.h"
+#include <toolshed.h>
+
+void test_os9_command_format()
+{
+	error_code ec;
+	native_path_id nativepath;
+	u_int size;
+
+	ec = system("../os9/os9 format -e test.dsk -l65000 > /dev/null 2>&1");
+	ASSERT_EQUALS(0, ec);
+	
+	ec = _native_open(&nativepath, "test.dsk", FAM_READ);
+	ASSERT_EQUALS(0, ec);
+
+	ec = _native_gs_size(nativepath, &size);	
+	ASSERT_EQUALS(0, ec);
+	ASSERT_EQUALS(65000*256, size);
+	
+	ec = _native_close(nativepath);
+	ASSERT_EQUALS(0, ec);
+	
+}
+
+int main()
+{
+	remove("test.dsk");
+	RUN(test_os9_command_format);
+
+	remove("test.dsk");
+
+	return TEST_REPORT();
+}


### PR DESCRIPTION
This is an alternate way to fix issue #28.
Also I created a seperate os9 command test file.