### PR TITLE
Add new build targets & update workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,16 +35,14 @@ jobs:
 
     - name: Build Linux
       run: |
-        sudo make -C build/unix package
-
+        sudo make -C build/unix unixpackage
       
     - name: Build Windows
       run: |
-        sudo make -C build/unix cleandirs 
-        sudo make -C build/unix CC=x86_64-w64-mingw32-gcc WIN=1 package || exit 1
+        sudo make -C build/unix winpackage
 
     - name: Results
       run: |
-        md5sum build/unix/toolshed-*.tgz
-        ls build/unix/toolshed-*.tgz | xargs -I {} bash -c 'ls -al --color=auto {}; tar tzvf {}'
+        [ -f build/unix/toolshed-*.tgz ] && ls build/unix/toolshed-*.tgz | xargs -I {} bash -c 'echo; md5sum {}; ls -al --color=auto {}; tar tzvf {}'
+        [ -f build/unix/toolshed-*.zip ] && ls build/unix/toolshed-*.zip | xargs -I {} bash -c 'echo; md5sum {}; ls -al --color=auto {}; unzip -l -v {}'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,20 +18,32 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Setup Requirements
+      run: |
+        sudo apt-get install mingw-w64 markdown libfuse-dev
+
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Build
+    - name: Build Linux
       run: |
-        sudo apt-get install mingw-w64 markdown libfuse-dev
-        sudo make -C build/unix package
-        sudo make -C build/unix cleandirs
-        sudo make -C build/unix CC=x86_64-w64-mingw32-gcc WIN=1 package
+        sudo make -C build/unix unixpackage
+      
+    - name: Build Windows
+      run: |
+        sudo make -C build/unix winpackage
+
+    - name: Results
+      run: |
+        [ -f build/unix/toolshed-*.tgz ] && ls build/unix/toolshed-*.tgz | xargs -I {} bash -c 'echo; md5sum {}; ls -al --color=auto {}; tar tzvf {}'
+        [ -f build/unix/toolshed-*.zip ] && ls build/unix/toolshed-*.zip | xargs -I {} bash -c 'echo; md5sum {}; ls -al --color=auto {}; unzip -l -v {}'
 
     - name: Release
       uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        files: "build/unix/toolshed-*.tgz"
+        files: |
+          "build/unix/toolshed-*.tgz"
+          "build/unix/toolshed-*.zip"
 

--- a/build/unix/Makefile
+++ b/build/unix/Makefile
@@ -4,7 +4,9 @@ include rules.mak
 
 vpath %.c ../../mamou:../../os9
 
-PACKAGENAME	= toolshed-unix64-$(VERSION).tgz
+PACKAGENAME_UNIX	= toolshed-unix64-$(VERSION).tgz
+PACKAGENAME_WIN		= toolshed-win64-$(VERSION).zip
+
 ifneq ($(DESTDIR),)
 INSTALLDIR	= $(DESTDIR)/usr/bin
 DOCDIR		= $(DESTDIR)/usr/share/doc/toolshed
@@ -20,8 +22,11 @@ DIRS		= libtoolshed libnative libcecb librbf libcoco libdecb libmisc libsys \
 		doc
 
 ifneq ($(WIN),)
-PACKAGENAME	= toolshed-win64-$(VERSION).tgz
+PACKAGENAME	= $(PACKAGENAME_WIN)
+MAKEPACKAGE = zip -9
 else
+PACKAGENAME	= $(PACKAGENAME_UNIX)
+MAKEPACKAGE = tar czvf
 DIRS		:= $(DIRS) cocofuse lst2cmt unittest
 APPS		:= $(APPS) cocofuse
 endif
@@ -39,11 +44,22 @@ install: all
 package: INSTALLDIR=toolshed-$(VERSION)
 package: DOCDIR = $(INSTALLDIR)
 package: install
-	tar czvf $(PACKAGENAME) toolshed-$(VERSION)
+	$(MAKEPACKAGE) $(PACKAGENAME) toolshed-$(VERSION)/*
 	rm -rf toolshed-$(VERSION)
 
 cleandirs:
 	$(foreach dir, $(DIRS), (cd $(dir); $(MAKE) clean);)
 	
 clean: cleandirs
-	$(RM) $(PACKAGENAME)
+	$(RM) $(PACKAGENAME_WIN) $(PACKAGENAME_UNIX)
+
+unixpackage:
+	$(MAKE) -f ./Makefile package
+
+winpackage:
+	$(MAKE) -f ./Makefile cleandirs
+	$(MAKE) -f ./Makefile CC=x86_64-w64-mingw32-gcc WIN=1 package
+
+allpackages: clean unixpackage winpackage 
+
+


### PR DESCRIPTION
workflows:
- updated release workflow to match the same steps of the build workflow
- moved each platform to the makefile (unixpackage & winpackage)

makefile:
- ensure 'clean' cleans both packages always
- added 'allpackages' target to build all the packages in one go
