### PR TITLE
Drop quotes from make release workflow / add lst2cmt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,11 @@ jobs:
         [ -f build/unix/toolshed-*.zip ] && ls build/unix/toolshed-*.zip | xargs -I {} bash -c 'echo; md5sum {}; ls -al --color=auto {}; unzip -l -v {}'
 
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         files: |
-          "build/unix/toolshed-*.tgz"
-          "build/unix/toolshed-*.zip"
+          build/unix/toolshed-*.tgz
+          build/unix/toolshed-*.zip
 

--- a/build/unix/Makefile
+++ b/build/unix/Makefile
@@ -14,10 +14,10 @@ else
 INSTALLDIR	= /usr/local/bin
 DOCDIR		= /usr/local/share/toolshed
 endif
-APPS 		= ar2 os9 mamou cecb decb tocgen makewav dis68
+APPS 		= ar2 os9 mamou cecb decb tocgen makewav dis68 lst2cmt
 
 DIRS		= libtoolshed libnative libcecb librbf libcoco libdecb libmisc libsys \
-		decb cecb os9 makewav tocgen \
+		decb cecb os9 makewav tocgen lst2cmt \
 		dis68 mamou ar2 \
 		doc
 
@@ -27,7 +27,7 @@ MAKEPACKAGE = zip -9
 else
 PACKAGENAME	= $(PACKAGENAME_UNIX)
 MAKEPACKAGE = tar czvf
-DIRS		:= $(DIRS) cocofuse lst2cmt unittest
+DIRS		:= $(DIRS) cocofuse unittest
 APPS		:= $(APPS) cocofuse
 endif
 

--- a/build/unix/lst2cmt/Makefile
+++ b/build/unix/lst2cmt/Makefile
@@ -6,7 +6,7 @@ vpath %.c ../../../lst2cmt
 CFLAGS	+= -I../../../include -Wall
 #LDFLAGS	+=
 
-lst2cmt:	lst2cmt.o
+lst2cmt$(SUFEXE):	lst2cmt.o
 	$(CC) -o $@ $^ $(LDFLAGS)
 
 clean:


### PR DESCRIPTION
- switch to version 2
- drop quotes around filenames causing failure
- add lst2cmt to packages